### PR TITLE
PHP8 fix for testEWarning

### DIFF
--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -7,6 +7,6 @@ class ErrorHandlerTest extends TestCase
     public function testEWarning()
     {
         $this->expectException(\ErrorException::class);
-        trigger_error('Demo warning', E_WARNING);
+        trigger_error('Demo warning', E_USER_WARNING);
     }
 }


### PR DESCRIPTION
```text
There was 1 failure:

1) ApprovalTests\Tests\ErrorHandlerTest::testEWarning
Failed asserting that exception of type "ValueError" matches expected exception "ErrorException". Message was: "trigger_error(): Argument #2 ($error_level) must be one of E_USER_ERROR, E_USER_WARNING, E_USER_NOTICE, or E_USER_DEPRECATED" at
/app/tests/ErrorHandlerTest.php:10
```

The fix is to change the test from `E_WARNING` to `E_USER_WARNING`

I've checked PHP7.2 to PHP8, all tests OK (15 tests, 28 assertions) now pass.

FYI. Thire is a problem with the Str dependency too, I have put in a pull request to fix `vendor/delight-im/str/src/Str.php:719`

`ErrorException: Required parameter $alwaysRemoveWhitespace follows optional parameter $charactersToRemove`

Once both are approved can update the Gilded Rose Kata to allow PHP8.

Thanks for your consideration.