### PR TITLE
Remove new types to work on PHP 5.6

### DIFF
--- a/src/CombinationApprovals.php
+++ b/src/CombinationApprovals.php
@@ -84,7 +84,7 @@ class CombinationApprovals
         Approvals::verifyString($output, $reporter);
     }
 
-    public static function displayArguments(...$args): string
+    public static function displayArguments(...$args)
     {
         return '[' . implode(', ', array_filter($args, function($i) { return $i !== self::$empty[0]; })) . "] => ";
     }

--- a/src/FileApprover.php
+++ b/src/FileApprover.php
@@ -4,7 +4,7 @@ namespace ApprovalTests;
 
 class FileApprover
 {
-    public static function checkFiles(string $approvedFilename, string $receivedFilename): bool
+    public static function checkFiles($approvedFilename, $receivedFilename)
     {
         $approvedContents = FileApprover::clean(file_get_contents($approvedFilename));
         $receivedContents = FileApprover::clean(file_get_contents($receivedFilename));
@@ -12,7 +12,7 @@ class FileApprover
         return $approvedContents === $receivedContents;
     }
 
-    private static function clean(string $contents): string
+    private static function clean($contents)
     {
         return str_replace("\r\n", "\n", $contents);
     }

--- a/src/Namers/PHPUnitNamer.php
+++ b/src/Namers/PHPUnitNamer.php
@@ -68,7 +68,7 @@ class StackTraceMetadata
         return substr($haystack, -$length) === $needle;
     }
 
-    public function __toString(): string {
+    public function __toString() {
         return "[PHPUnit,class,method,reflection,testDirectory]="
             ."[{$this->isPHPUnitTest},{$this->class},{$this->function},{$this->isReflection},{$this->testDirectory}]";
     }

--- a/src/Reporters/DiffInfo.php
+++ b/src/Reporters/DiffInfo.php
@@ -8,14 +8,14 @@ class DiffInfo
     public $parameters;
     public $fileExtensions;
 
-    public function __construct(string $diffProgram, array $fileExtensions, string $parameters = null)
+    public function __construct($diffProgram, array $fileExtensions, $parameters = null)
     {
         $this->diffProgram = self::resolveWindowsPath($diffProgram);
-        $this->parameters = $parameters ?? GenericDiffReporter::$STANDARD_ARGUMENTS;
+        $this->parameters = $parameters ?: GenericDiffReporter::$STANDARD_ARGUMENTS;
         $this->fileExtensions = $fileExtensions;
     }
 
-    private static function resolveWindowsPath(string $diffProgram): string
+    private static function resolveWindowsPath($diffProgram)
     {
         $tag = "{ProgramFiles}";
         
@@ -26,13 +26,13 @@ class DiffInfo
         return $diffProgram;
     }
 
-    private static function getPathInProgramFilesX86(string $path): string
+    private static function getPathInProgramFilesX86($path)
     {
         $paths = self::getProgramFilesPaths();
         return self::getFirstWorking($path, $paths, "C:\\Program Files\\");
     }
 
-    public static function getFirstWorking(string $path, array $paths, string $ifNotFoundDefault): string
+    public static function getFirstWorking($path, array $paths, $ifNotFoundDefault)
     {
         $fullPath = $ifNotFoundDefault . $path;
         foreach ($paths as $p) {
@@ -44,7 +44,7 @@ class DiffInfo
         return $fullPath;
     }
 
-    public static function getProgramFilesPaths(): array
+    public static function getProgramFilesPaths()
     {
         $paths = [
             getenv("ProgramFiles(x86)"),

--- a/src/Reporters/DiffPrograms.php
+++ b/src/Reporters/DiffPrograms.php
@@ -6,7 +6,7 @@ class DiffPrograms
 {
     private static $instance = null;
 
-    public static function getInstance(): DiffPrograms {
+    public static function getInstance() {
         if (!self::$instance) {
             self::$instance = new DiffPrograms();
         }

--- a/src/Reporters/GenericDiffReporter.php
+++ b/src/Reporters/GenericDiffReporter.php
@@ -16,7 +16,7 @@ class GenericDiffReporter implements Reporter
     private $fileExtensions;
     private $parameters;
 
-    public function __construct(string $diffProgram, array $fileExtensions, string $parameters) {
+    public function __construct($diffProgram, array $fileExtensions, $parameters) {
         $this->diffProgram = $diffProgram;
         $this->fileExtensions = $fileExtensions;
         $this->parameters = $parameters;

--- a/src/Reporters/Mac/MacDiffInfoReporter.php
+++ b/src/Reporters/Mac/MacDiffInfoReporter.php
@@ -7,7 +7,7 @@ use ApprovalTests\Reporters\GenericDiffReporter;
 
 class MacDiffInfoReporter extends GenericDiffReporter
 {
-    public function __construct(string $diffInfoName)
+    public function __construct($diffInfoName)
     {
         $diffInfo = DiffPrograms::getInstance()->MacDiffPrograms[$diffInfoName];
         parent::__construct($diffInfo->diffProgram, $diffInfo->fileExtensions, $diffInfo->parameters);

--- a/src/Reporters/Windows/WindowsDiffInfoReporter.php
+++ b/src/Reporters/Windows/WindowsDiffInfoReporter.php
@@ -7,7 +7,7 @@ use ApprovalTests\Reporters\GenericDiffReporter;
 
 class WindowsDiffInfoReporter extends GenericDiffReporter
 {
-    public function __construct(string $diffInfoName)
+    public function __construct($diffInfoName)
     {
         $diffInfo = DiffPrograms::getInstance()->WindowsDiffPrograms[$diffInfoName];
         parent::__construct($diffInfo->diffProgram, $diffInfo->fileExtensions, $diffInfo->parameters);

--- a/src/SystemUtil.php
+++ b/src/SystemUtil.php
@@ -4,7 +4,7 @@ namespace ApprovalTests;
 
 class SystemUtil
 {
-    public static function isWindows(): bool
+    public static function isWindows()
     {
         // Based on http://php.net/manual/en/function.php-uname.php
         return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';

--- a/src/Writers/TextWriter.php
+++ b/src/Writers/TextWriter.php
@@ -21,21 +21,21 @@ class TextWriter implements Writer
     /**
      * Write the file to disk
      */
-    public function write(string $fileNameAndPath, string $approvalsFolder)
+    public function write($fileNameAndPath, $approvalsFolder)
     {
         FileUtil::createFolderIfNotExists($approvalsFolder);
         file_put_contents($fileNameAndPath, $this->received);
         return $fileNameAndPath;
     }
 
-    public function writeEmpty(string $fileNameAndPath, string $approvalsFolder)
+    public function writeEmpty($fileNameAndPath, $approvalsFolder)
     {
         FileUtil::createFolderIfNotExists($approvalsFolder);
         file_put_contents($fileNameAndPath, "  ");
         return $fileNameAndPath;
     }
 
-    public function delete(string $fileNameAndPath)
+    public function delete($fileNameAndPath)
     {
         return unlink($fileNameAndPath);
     }

--- a/src/Writers/Writer.php
+++ b/src/Writers/Writer.php
@@ -6,8 +6,8 @@ interface Writer
 {
     public function getExtensionWithoutDot();
 
-    public function write(string $fileNameAndPath, string $approvalsFolder);
-    public function writeEmpty(string $fileNameAndPath, string $approvalsFolder);
+    public function write($fileNameAndPath, $approvalsFolder);
+    public function writeEmpty($fileNameAndPath, $approvalsFolder);
 
-    public function delete(string $fileNameAndPath);
+    public function delete($fileNameAndPath);
 }


### PR DESCRIPTION
Rollback new PHP types assignment in method definitions to make it work on old version of PHP.